### PR TITLE
Math functions

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -2,7 +2,7 @@ import { Board, GeometryElement, JSXGraph } from 'jsxgraph';
 import { Plugin } from 'obsidian';
 import { renderError } from 'src/error';
 import { GraphInfo } from 'src/types';
-import { addElement, createBoard, parseCodeBlock } from 'src/utils';
+import { addElement, createBoard, parseCodeBlock, setMathFunctions } from 'src/utils';
 import "./src/theme/obsidian.ts"
 
 export default class ObsidianGraphs extends Plugin {
@@ -10,6 +10,7 @@ export default class ObsidianGraphs extends Plugin {
 	graphDivs: HTMLElement[] = [];
 
 	async onload () {
+		setMathFunctions();
 
 		this.registerMarkdownCodeBlockProcessor("graph", (source, element, context) => {
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,17 @@ import { Board, JSXGraph, GeometryElement } from "jsxgraph";
 import { parseYaml } from "obsidian";
 import { ElementInfo, GraphInfo } from "./types";
 
+const args = {};
+const argsArray = Object.getOwnPropertyNames(Math) ;
+const mathFunctions: any[] = [];
+
+export function setMathFunctions() {
+	for (const name of Object.getOwnPropertyNames(Math)) {
+		//@ts-ignore
+		mathFunctions.push(Math[name]);
+	}
+}
+
 export function parseCodeBlock(source: string) :GraphInfo {
 	let graph: GraphInfo = {bounds: [], keepAspectRatio: false, showNavigation: true, axis: true,  elements: []};
 
@@ -198,15 +209,21 @@ function checkForFunction(element: ElementInfo, eindex: number, createdElements:
 				composed = re.exec(element.def[eindex]);
 			}
 
-			const args = {}
+			argsArray.push("createdElements");
+			argsArray.push("x");
+			argsArray.push("y");
 
 			const equation = element.def[eindex];
 			// create function that is used to calculate the values
-			element.def[eindex] = new Function("createdElements", "x", "y", "return " + equation + ";").bind(args, createdElements);
+			element.def[eindex] = new Function(argsArray.toString(), "return " + equation + ";").bind(args, ...mathFunctions, createdElements);
 		}
 		else { // no composed elements
 			const equation = element.def[eindex];
-			element.def[eindex] = new Function("x", "y", "return " + equation + ";");
+
+			argsArray.push("x");
+			argsArray.push("y");
+
+			element.def[eindex] = new Function(argsArray.toString(), "return " + equation + ";").bind(args, ...mathFunctions);
 		}
 	}
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -209,21 +209,14 @@ function checkForFunction(element: ElementInfo, eindex: number, createdElements:
 				composed = re.exec(element.def[eindex]);
 			}
 
-			argsArray.push("createdElements");
-			argsArray.push("x");
-			argsArray.push("y");
-
 			const equation = element.def[eindex];
 			// create function that is used to calculate the values
-			element.def[eindex] = new Function(argsArray.toString(), "return " + equation + ";").bind(args, ...mathFunctions, createdElements);
+			element.def[eindex] = new Function(...argsArray, "createdElements", "x", "y", "return " + equation + ";").bind(args, ...mathFunctions, createdElements);
 		}
 		else { // no composed elements
 			const equation = element.def[eindex];
 
-			argsArray.push("x");
-			argsArray.push("y");
-
-			element.def[eindex] = new Function(argsArray.toString(), "return " + equation + ";").bind(args, ...mathFunctions);
+			element.def[eindex] = new Function(...argsArray, "x", "y", "return " + equation + ";").bind(args, ...mathFunctions);
 		}
 	}
 }


### PR DESCRIPTION
This makes it so that Math functions are bound to functions that users create allowing them to not need to put `Math.` for every math function. For example instead of `Math.sin(x)` you can do `sin(x)`. This will make writing functions easy and it will be easier to read. The `checkForFunctions`  and `checkForComposed` functions were changed to be recursive which allows for arrays within arrays to be checked.