### PR TITLE
Fix live preview not rendering graphs randomly

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -34,44 +34,19 @@ export default class ObsidianGraphs extends Plugin {
 		}
 
 		this.app.workspace.on("file-open" , () => {
+			this.cullBoards();
+		});
 
+		this.app.workspace.on("window-close", () => {
+			this.cullBoards();
+		})
+
+		this.registerMarkdownCodeBlockProcessor("graph", (source, element) => {
 			const currentFile = this.app.workspace.getActiveFile();
 			if (currentFile) {
 				this.currentFileName = currentFile.name.substring(0, currentFile.name.indexOf("."))
 				this.currentFileName = this.currentFileName.replace(/\s/g, "");
 			}
-
-			// get the active files
-			const activeFileNames: string[] = [];
-			const files = this.app.workspace.getLeavesOfType("markdown");
-			files.forEach((file) => activeFileNames.push(file.getDisplayText().replace(/\s/g, "")));
-
-			// go through all the boards and delete ones that are not in active files
-			//@ts-ignore
-			for (const key in boards) {
-				let active = false;
-				//@ts-ignore
-				const div = boards[key].containerObj;
-
-				// check the if it is in the active files
-				for (const name of activeFileNames) {
-					if (div.hasClass(name)) {
-						active = true;
-						break;
-					}
-				}
-
-				// it is not in active files so delete
-				if (!active) {
-					//@ts-ignore
-					boards[key].containerObj.remove();
-					//@ts-ignore
-					JSXGraph.freeBoard(boards[key]);
-				}
-			}
-		});
-
-		this.registerMarkdownCodeBlockProcessor("graph", (source, element) => {
 
 			let graphInfo: GraphInfo;
 
@@ -118,6 +93,7 @@ export default class ObsidianGraphs extends Plugin {
 					}
 				}
 			}
+
 		});
 	}
 
@@ -142,5 +118,42 @@ export default class ObsidianGraphs extends Plugin {
 
 	async saveSettings() {
 		await this.saveData(this.settings);
+	}
+
+	cullBoards() {
+		const currentFile = this.app.workspace.getActiveFile();
+		if (currentFile) {
+			this.currentFileName = currentFile.name.substring(0, currentFile.name.indexOf("."))
+			this.currentFileName = this.currentFileName.replace(/\s/g, "");
+		}
+
+		// get the active files
+		const activeFileNames: string[] = [];
+		const files = this.app.workspace.getLeavesOfType("markdown");
+		files.forEach((file) => activeFileNames.push(file.getDisplayText().replace(/\s/g, "")));
+
+		// go through all the boards and delete ones that are not in active files
+		//@ts-ignore
+		for (const key in boards) {
+			let active = false;
+			//@ts-ignore
+			const div = boards[key].containerObj;
+
+			// check the if it is in the active files
+			for (const name of activeFileNames) {
+				if (div.hasClass(name)) {
+					active = true;
+					break;
+				}
+			}
+
+			// it is not in active files so delete
+			if (!active) {
+				//@ts-ignore
+				boards[key].containerObj.remove();
+				//@ts-ignore
+				JSXGraph.freeBoard(boards[key]);
+			}
+		}
 	}
 }

--- a/main.ts
+++ b/main.ts
@@ -8,7 +8,6 @@ import { Utils } from 'src/utils';
 
 export default class ObsidianGraphs extends Plugin {
 	settings: ObsidianGraphsSettings
-	currentFileName: string;
 	count = 0;
 	utils: Utils = new Utils();
 
@@ -42,12 +41,6 @@ export default class ObsidianGraphs extends Plugin {
 		})
 
 		this.registerMarkdownCodeBlockProcessor("graph", (source, element) => {
-			const currentFile = this.app.workspace.getActiveFile();
-			if (currentFile) {
-				this.currentFileName = currentFile.name.substring(0, currentFile.name.indexOf("."))
-				this.currentFileName = this.currentFileName.replace(/\s/g, "");
-			}
-
 			let graphInfo: GraphInfo;
 
 			try {
@@ -61,16 +54,10 @@ export default class ObsidianGraphs extends Plugin {
 			let graph: Graph;
 
 			// if the current file name is undefined need to get the current file
-			if (this.currentFileName == undefined) {
-				const currentFile = this.app.workspace.getActiveFile();
-				if (currentFile) {
-					this.currentFileName = currentFile.name.substring(0, currentFile.name.indexOf("."))
-					this.currentFileName = this.currentFileName.replace(/\s/g, "");
-				}
-			}
+			const currentFileName = this.getCurrentFileName();
 
 			// create the div that contains the board
-			const graphDiv = element.createEl("div", {cls: "jxgbox " + this.currentFileName});
+			const graphDiv = element.createEl("div", {cls: "jxgbox " + currentFileName});
 			graphDiv.id = "graph" + this.count;
 			this.count++;
 
@@ -120,13 +107,17 @@ export default class ObsidianGraphs extends Plugin {
 		await this.saveData(this.settings);
 	}
 
-	cullBoards() {
+	getCurrentFileName(): string {
+		let currentFileName = "";
 		const currentFile = this.app.workspace.getActiveFile();
 		if (currentFile) {
-			this.currentFileName = currentFile.name.substring(0, currentFile.name.indexOf("."))
-			this.currentFileName = this.currentFileName.replace(/\s/g, "");
+			currentFileName = currentFile.name.substring(0, currentFile.name.indexOf("."))
+			currentFileName = currentFileName.replace(/\s/g, "");
 		}
+		return currentFileName;
+	}
 
+	cullBoards() {
 		// get the active files
 		const activeFileNames: string[] = [];
 		const files = this.app.workspace.getLeavesOfType("markdown");


### PR DESCRIPTION
The `file-open` event was being called after some of the graphs were created causing them to get deleted when the `file-open` event was being called. This resulted in graphs not displaying when they should be.