### PR TITLE
Better syntax highlighting

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -17,7 +17,7 @@ export default class ObsidianGraphs extends Plugin {
 
 		this.addSettingTab(new ObsidianGraphsSettingsTab(this.app, this));
 
-		window.CodeMirror.defineMode("graph", config => window.CodeMirror.getMode(config, "yaml"));
+		window.CodeMirror.defineMode("graph", config => window.CodeMirror.getMode(config, "javascript"));
 
 		await loadMathJax();
 


### PR DESCRIPTION
Changed the language used for the `graph` codeblock highlighting to `javascript` this resulted in better syntax highlighting.

YAML
![image](https://github.com/user-attachments/assets/0c1dd0a7-3212-43c9-bb69-0e75768bc311)

Javascript
![image](https://github.com/user-attachments/assets/63fae7d9-4334-451c-9c9e-ac9741385304)
