### PR TITLE
Export mobile bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,6 @@ data.json
 .DS_Store
 
 # syyncthing
-.stfolder
-.syyncthing*
+.stfolder/
+.syncthing*
+.stignore

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ data.json
 
 # Exclude macOS Finder (System Explorer) View States
 .DS_Store
+
+# syyncthing
+.stfolder
+.syyncthing*

--- a/src/exportModal.ts
+++ b/src/exportModal.ts
@@ -55,15 +55,15 @@ export class ExportModal extends Modal {
 	}
 
 	renderCanvas(canvas: HTMLCanvasElement, svg: string) {
-		const widthString = svg.match(/width="([0-9]+)"/);
-		const heightString = svg.match(/height="([0-9]+)"/);
+		const widthString = svg.match(/width="([0-9]+.?[0-9]+)"/);
+		const heightString = svg.match(/height="([0-9]+.?[0-9]+)"/);
 
 		let width = 0;
 		let height = 0;
 
 		if (widthString && heightString) {
-			width = Number.parseInt(widthString[1]);
-			height = Number.parseInt(heightString[1]);
+			width = Number.parseFloat(widthString[1]);
+			height = Number.parseFloat(heightString[1]);
 		}
 
 		const ctx = canvas.getContext("2d");
@@ -172,15 +172,15 @@ export class ExportModal extends Modal {
 				this.svgs.push(svg);
 			}
 
-			const widthString = svg.match(/width="([0-9]+)"/);
-			const heightString = svg.match(/height="([0-9]+)"/);
+			const widthString = svg.match(/width="([0-9]+.?[0-9]+)"/);
+			const heightString = svg.match(/height="([0-9]+.?[0-9]+)"/);
 
 			let width = 0;
 			let height = 0;
 
 			if (widthString && heightString) {
-				width = Number.parseInt(widthString[1]);
-				height = Number.parseInt(heightString[1]);
+				width = Number.parseFloat(widthString[1]);
+				height = Number.parseFloat(heightString[1]);
 			}
 
 			if (width <=  0 || height <= 0) {


### PR DESCRIPTION
On mobile graphs do not show up in the export modal. The problem was that the height and width were being parsed as ints but on mobile with the small screen size they were floats causing an error when parsing.