### PR TITLE
Export PNG bug

### DIFF
--- a/src/exportModal.ts
+++ b/src/exportModal.ts
@@ -232,8 +232,7 @@ export class ExportModal extends Modal {
 								u8arr[i] = bstr.charCodeAt(i);
 							}
 
-							//@ts-ignore
-							this.app.vault.create(path, u8arr);
+							this.app.vault.createBinary(path, u8arr);
 						}
 						else {
 							this.app.vault.create(path, this.svgs[graphNumber-1]);


### PR DESCRIPTION
On mobile exporting to png was failing. Needed to use `vault.createBinary()`.