### PR TITLE
add "graph3d" code block language as a shortcut for 3d graphs

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-import { loadMathJax, MarkdownView, Plugin } from 'obsidian';
+import { loadMathJax, MarkdownPostProcessorContext, MarkdownView, Plugin } from 'obsidian';
 import { JSXGraph } from 'jsxgraph';
 import { renderError } from 'src/error';
 import { Graph, GraphInfo } from 'src/types';
@@ -19,6 +19,7 @@ export default class Graphs extends Plugin {
 		this.addSettingTab(new GraphsSettingsTab(this.app, this));
 
 		window.CodeMirror.defineMode("graph", config => window.CodeMirror.getMode(config, "javascript"));
+		window.CodeMirror.defineMode("graph3d", config => window.CodeMirror.getMode(config, "javascript"));
 
 		await loadMathJax();
 
@@ -69,11 +70,20 @@ export default class Graphs extends Plugin {
 		});
 
 		this.registerMarkdownCodeBlockProcessor("graph", (source, element) => {
+			this.handleCodeBlock(source, element, false);
+		});
+		this.registerMarkdownCodeBlockProcessor("graph3d", (source, element) => {
+			this.handleCodeBlock(source, element, true);
+		});
+	}
+	
+	handleCodeBlock(source:string, element : HTMLElement, is3d : boolean) {
+		{
 			let graphInfo: GraphInfo;
 
 			try {
 				// parse the JSON from the code block
-				graphInfo = this.utils.parseCodeBlock(source);
+				graphInfo = this.utils.parseCodeBlock(source, is3d);
 			} catch (e) {
 				renderError(e,element);
 				return;
@@ -121,7 +131,7 @@ export default class Graphs extends Plugin {
 					}
 				}
 			}
-		});
+		}
 	}
 
 	onunload() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "Graphs",
-	"version": "1.8.0",
+	"version": "1.9.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "Graphs",
-			"version": "1.8.0",
+			"version": "1.9.1",
 			"license": "MIT",
 			"dependencies": {
 				"jsxgraph": "^1.7.0"

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,7 +16,7 @@ export class Utils {
 		}
 	}
 
-	parseCodeBlock(source: string) :GraphInfo {
+	parseCodeBlock(source: string, is3d : boolean) :GraphInfo {
 		let graph: GraphInfo = {bounds: [0,0,0,0],
 								maxBoundingBox: JXG.Options.board.maxBoundingBox,
 								keepAspectRatio: false,
@@ -45,16 +45,31 @@ export class Utils {
 				graph.showNavigation = true;
 			}
 
-			if (graph.axis == undefined) {
-				graph.axis = true;
+			if (is3d) {
+				if (graph.bounds3d == undefined) {
+					graph.bounds3d = [[-5,5],[-5,5],[-5,5]];
+				}
+				if (graph.axis == undefined) {
+					graph.axis = false;
+				}
+				if (graph.keepAspectRatio == undefined) {
+					graph.keepAspectRatio = true;
+				}
+			} else {
+				if (graph.axis == undefined) {
+					graph.axis = true;
+				}
 			}
-
 			if (graph.defaultAxes == undefined) {
 				graph.defaultAxes = JXG.Options.board.defaultAxes;
 			}
 
 			if (graph.drag == undefined) {
 				graph.drag = true;
+			}
+
+			if (graph.bounds == undefined) {
+				graph.bounds = [-10,10,10,-10]
 			}
 
 			return graph;


### PR DESCRIPTION
Not sure if this aligns with your design ideals for your plugin at all, but this is a change I made just to suit my own tastes.
It just adds a "graph3d" code block type in addition to the "graph" code block type. The only difference when the "graph3d" type is used is that it assumes a 3d graph and adds bounds3d if missing, as well as the settings recommended in the wiki.